### PR TITLE
chore: mention REUSE tool in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Data Synthesis for Machine Learning
 
+[![REUSE status](https://api.reuse.software/badge/github.com/SAP/data-synthesis-for-machine-learning)](https://api.reuse.software/info/github.com/SAP/data-synthesis-for-machine-learning)
+
 ## Overview
 The recent enforcement of data privacy protection regulations, such as GDPR, has made data sharing more difficult. This tool intends to facilitate data sharing from a customer by synthesizing a dataset based on the original dataset for later machine learning. 
 There are two parts to this tool:
@@ -154,3 +156,7 @@ If you encounter an issue, you can open an issue in GitHub.
 
 ## Contribute
 Please check our [Contribution Guidelines](/CONTRIBUTING.md).
+
+## Licensing
+
+Copyright 2019-2021 SAP SE or an SAP affiliate company and data-synthesis-for-machine-learning contributors. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/SAP/data-synthesis-for-machine-learning).


### PR DESCRIPTION
In line with SAP OSPO requirements, this PR adds the REUSE Tool links to the README

**Notes:** 
- Please register the repository with the REUSE Tool to complete the integration (see #16 and #17)

Fixes #15